### PR TITLE
Update Constants section with enum proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,16 +146,16 @@ Find more information about localization in [these presentation slides][l10n-sli
 
 #### Constants
 
-Keep your constants' scope as small as possible. For instance, when you only need it inside a class, it should live in that class. Those constants that need to be truly app-wide should be kept in one place. In Swift, you can use structs defined in a `Constants.swift` file to group, store and access your app-wide constants in a clean way:
+Keep your constants' scope as small as possible. For instance, when you only need it inside a class, it should live in that class. Those constants that need to be truly app-wide should be kept in one place. In Swift, you can use enums defined in a `Constants.swift` file to group, store and access your app-wide constants in a clean way:
 
 ```swift
 
-struct Config {
+enum Config {
     static let baseURL = NSURL(string: "http://www.example.org/")!
     static let splineReticulatorName = "foobar"
 }
 
-struct Color {
+enum Color {
     static let primaryColor = UIColor(red: 0.22, green: 0.58, blue: 0.29, alpha: 1.0)
     static let secondaryColor = UIColor.lightGrayColor()
 }


### PR DESCRIPTION
Thanks for gathering all these information and best-practises for daily Swift development. Since the aim is to apply best-practises, I have a minor proposal related to the way Constants are stored in the project.

Current constants section suggests having app-wide constant in a `struct` as follows

```swift
struct Config {
    static let baseURL = NSURL(string: "http://www.example.org/")!
    static let splineReticulatorName = "foobar"
}
```

Structs are definitely good but enums are better in this case. Since enums are good for representing finite sets like constants, it fits better. 

```swift
enum Config {
    static let baseURL = NSURL(string: "http://www.example.org/")!
    static let splineReticulatorName = "foobar"
}
```

The advantage of using a case-less enumeration is that it can't accidentally be instantiated and works as a pure namespace. While following is possible for a struct `let foo = Config()`, it is not possible for enums `let foo = Config() <- Compile time error`

You can also find a similar discussion here: https://stackoverflow.com/questions/38585344/swift-constants-struct-or-enum

